### PR TITLE
add_show_method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/EvalMetrics.jl
+++ b/src/EvalMetrics.jl
@@ -7,6 +7,7 @@ import Statistics: quantile
 import StatsBase: RealVector
 using RecipesBase
 using Reexport
+using PrettyTables
 
 include("encodings/Encodings.jl")
 @reexport using .Encodings

--- a/src/confusion_matrix.jl
+++ b/src/confusion_matrix.jl
@@ -7,7 +7,7 @@ struct ConfusionMatrix{T<:Real}
     fn::T   # (incorrect) negative prediction when target is positive
 end
 
-function show(io::IO, cm::ConfusionMatrix)
+function show(io::IO, ::MIME"text/plain", cm::ConfusionMatrix)
     pretty_table(io,
     linebreaks=true,
     alignment=:C,

--- a/src/confusion_matrix.jl
+++ b/src/confusion_matrix.jl
@@ -7,6 +7,20 @@ struct ConfusionMatrix{T<:Real}
     fn::T   # (incorrect) negative prediction when target is positive
 end
 
+function show(io::IO, cm::ConfusionMatrix)
+    pretty_table(io,
+    linebreaks=true,
+    alignment=:C,
+    body_hlines = [1, 2, 3],
+    noheader=true,
+        [
+            "Tot = $(+(cm.p, cm.n)) "     "Actual\npositives"   "Actual\nnegatives"
+            "Prediced\npositives"         cm.tp                 cm.fp
+            "Prediced\nnegatives"         cm.fn                 cm.tn
+        ]
+    )
+end
+
 
 function Base.:(+)(a::ConfusionMatrix{T}, b::ConfusionMatrix{S}) where {T, S}
     ConfusionMatrix{promote_type(T,S)}(


### PR DESCRIPTION
This PR adds a dependency on PrettyTables.jl, which is used to print pretty confusion matrices.

Before:
```
julia> ConfusionMatrix(2, 2, 1, 1, 1, 1)
ConfusionMatrix{Int64}(2, 2, 1, 1, 1, 1)
```

After:
```
julia> ConfusionMatrix(2, 2, 1, 1, 1, 1)        
┌───────────┬───────────┬───────────┐
│ Tot = 4   │  Actual   │  Actual   │
│           │ positives │ negatives │
├───────────┼───────────┼───────────┤
│ Prediced  │     1     │     1     │
│ positives │           │           │
├───────────┼───────────┼───────────┤
│ Prediced  │     1     │     1     │
│ negatives │           │           │
└───────────┴───────────┴───────────┘
```

There is a large amount of customization that can be done - this is my simple take on it, which looks good enough to me. Feel free to suggest changes.